### PR TITLE
add stats tables to mysql init script

### DIFF
--- a/docker/homer-heplify/docker-compose.yml
+++ b/docker/homer-heplify/docker-compose.yml
@@ -56,3 +56,13 @@ services:
     depends_on:
       dbmysql:
          condition: service_healthy
+
+  telegraf:
+    image: telegraf:0.12
+    restart: unless-stopped
+    volumes:
+      - ./telegraf.conf:/etc/telegraf/telegraf.conf:ro
+    ports:
+      - "8092:8092/udp"
+      - "8094:8094"
+      - "8125:8125/udp"

--- a/docker/homer-heplify/init_db.sql
+++ b/docker/homer-heplify/init_db.sql
@@ -214,6 +214,42 @@ CREATE TABLE IF NOT EXISTS `api_auth_key` (
   UNIQUE KEY `authkey` (`authkey`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1 AUTO_INCREMENT=1 ;
 
+--
+-- Table structure for statistics
+--
+
+CREATE TABLE IF NOT EXISTS `stats_data` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `from_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `to_date` timestamp NOT NULL DEFAULT '1971-01-01 00:00:01',
+  `type` varchar(50) NOT NULL DEFAULT '',
+  `total` int(20) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`,`from_date`),
+  UNIQUE KEY `datemethod` (`from_date`,`to_date`,`type`),
+  KEY `from_date` (`from_date`),
+  KEY `to_date` (`to_date`),
+  KEY `method` (`type`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
+/*!50100 PARTITION BY RANGE ( UNIX_TIMESTAMP(`from_date`))
+(PARTITION pmax VALUES LESS THAN MAXVALUE ENGINE = InnoDB) */ ;
+
+CREATE TABLE IF NOT EXISTS `stats_method` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `from_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `to_date` timestamp NOT NULL DEFAULT '1971-01-01 00:00:01',
+  `method` varchar(50) NOT NULL DEFAULT '',
+  `auth` tinyint(1) NOT NULL DEFAULT '0',
+  `cseq` varchar(100) NOT NULL DEFAULT '',
+  `totag` tinyint(1) NOT NULL DEFAULT 0,
+  `total` int(20) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`,`from_date`),
+  UNIQUE KEY `datemethod` (`from_date`,`to_date`,`method`,`auth`,`totag`,`cseq`),
+  KEY `from_date` (`from_date`),
+  KEY `to_date` (`to_date`),
+  KEY `method` (`method`),
+  KEY `completed` (`cseq`)
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
+
 
 USE mysql;
 INSERT INTO `user` VALUES ('localhost','homer_user','*D0F60D1E3C6C124FEEB76527E00A9380C37643EE','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','','','','',0,0,0,0,'mysql_native_password','','N');

--- a/docker/homer-heplify/init_db.sql
+++ b/docker/homer-heplify/init_db.sql
@@ -249,7 +249,8 @@ CREATE TABLE IF NOT EXISTS `stats_method` (
   KEY `method` (`method`),
   KEY `completed` (`cseq`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8
-
+/*!50100 PARTITION BY RANGE ( UNIX_TIMESTAMP(`from_date`))
+(PARTITION pmax VALUES LESS THAN MAXVALUE ENGINE = InnoDB) */ ;
 
 USE mysql;
 INSERT INTO `user` VALUES ('localhost','homer_user','*D0F60D1E3C6C124FEEB76527E00A9380C37643EE','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','','','','',0,0,0,0,'mysql_native_password','','N');

--- a/docker/homer-heplify/telegraf.conf
+++ b/docker/homer-heplify/telegraf.conf
@@ -1,0 +1,59 @@
+# Telegraf configuration
+
+[global_tags]
+  # dc = "us-east-1" # will tag all metrics with dc=us-east-1
+  # rack = "1a"
+
+# Configuration for telegraf agent
+[agent]
+  ## Default data collection interval for all inputs
+  interval = "30s"
+  ## Rounds collection interval to 'interval'
+  ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+  round_interval = true
+
+  ## Telegraf will cache metric_buffer_limit metrics for each output, and will
+  ## flush this buffer on a successful write.
+  metric_buffer_limit = 10000
+  ## Flush the buffer whenever full, regardless of flush_interval.
+  flush_buffer_when_full = true
+
+  ## Collection jitter is used to jitter the collection by a random amount.
+  ## Each plugin will sleep for a random time within jitter before collecting.
+  ## This can be used to avoid many plugins querying things like sysfs at the
+  ## same time, which can have a measurable effect on the system.
+  collection_jitter = "0s"
+
+  ## Default flushing interval for all outputs. You shouldn't set this below
+  ## interval. Maximum flush_interval will be flush_interval + flush_jitter
+  flush_interval = "10s"
+  ## Jitter the flush interval by a random amount. This is primarily to avoid
+  ## large write spikes for users running a large number of telegraf instances.
+  ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+  flush_jitter = "0s"
+
+  ## Run telegraf in debug mode
+  debug = false
+  ## Run telegraf in quiet mode
+  quiet = false
+  ## Override default hostname, if empty use os.Hostname()
+  hostname = ""
+
+###############################################################################
+#                                  OUTPUTS                                    #
+###############################################################################
+
+[[outputs.socket_writer]]
+  #Node JS udp or tcp socket
+  address = "udp://telestats:8094"
+  # keep_alive_period = "5m"
+  data_format = "json"
+  json_timestamp_units = "1ns"
+
+###############################################################################
+#                                  INPUTS                                     #
+###############################################################################
+
+[[inputs.prometheus]]
+ ## An array of urls to scrape metrics from.
+ urls = ["http://heplify:9999/metrics"]


### PR DESCRIPTION
Since table inserts for v1 are external, I placed the table creation in the generic init script